### PR TITLE
Update Readme compile configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The minimum supported SDK version is 15
 **Step 2.** Add the dependency
 
     dependencies {
-	     compile 'com.github.Flutterwave:rave-android:1.0.28'
+	     implementation 'com.github.Flutterwave:rave-android:1.0.28'
 	}
 
 **Step 3.** Add the required permission


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html